### PR TITLE
Fixing material design references

### DIFF
--- a/FitnessTracker/App.xaml
+++ b/FitnessTracker/App.xaml
@@ -2,31 +2,32 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:FitnessTracker"
-			 xmlns:vm="clr-namespace:FitnessTracker.ViewModels"
-			 xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
-			 xmlns:u="clr-namespace:FitnessTracker.Utilities"
-			 xmlns:c="clr-namespace:FitnessTracker.Converters"
+             xmlns:vm="clr-namespace:FitnessTracker.ViewModels"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:u="clr-namespace:FitnessTracker.Utilities"
+             xmlns:c="clr-namespace:FitnessTracker.Converters"
              StartupUri="views\MainWindowView.xaml">
-	<Application.Resources>
-		<ResourceDictionary>
-			<!-- Uncomment for compiler failure do to BundledTheme not being found in the namespace -->
-			<!--<ResourceDictionary.MergedDictionaries>
-				<materialDesign:BundledTheme BaseTheme="Light" PrimaryColor="DeepPurple" SecondaryColor="Lime" />
-				<ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml" />
-			</ResourceDictionary.MergedDictionaries>-->
-			
-			<!-- Uncomment to see the project compile, but fail due to a missing MaterialDesignThemes.Wpf.dll file -->
-			<!--<ResourceDictionary.MergedDictionaries>
-				<ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Light.xaml" />
-				<ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Primary/MaterialDesignColor.DeepPurple.xaml" />
-				<ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Accent/MaterialDesignColor.Lime.xaml" />
-			</ResourceDictionary.MergedDictionaries>-->
-			
-			<u:ViewModelLocator x:Key="Locator" />
-			<c:SharedValueConverter x:Key="SharedConverter" />
-			<c:BooleanToVisibilityConverter x:Key="TrueToVisibileConverter" True="Visible" False="Collapsed" />
-			<c:BooleanToVisibilityConverter x:Key="FalseToVisibleConverter" True="Collapsed" False="Visible" />
-			<c:InverseCombineAndBooleansConverter x:Key="InverseCombineBooleanConverter" />
-		</ResourceDictionary>
-	</Application.Resources>
+    <Application.Resources>
+        <ResourceDictionary>
+            <!-- Uncomment for compiler failure do to BundledTheme not being found in the namespace -->
+            <!-- In version 3.2.0 you can set BaseTheme to Inherit and on Windows 10, it will go light or Dark theme based on the user's Windows theme -->
+            <ResourceDictionary.MergedDictionaries>
+                <materialDesign:BundledTheme BaseTheme="Light" PrimaryColor="DeepPurple" SecondaryColor="Lime" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+            
+            <!-- Uncomment to see the project compile, but fail due to a missing MaterialDesignThemes.Wpf.dll file -->
+            <!--<ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Light.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Primary/MaterialDesignColor.DeepPurple.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Accent/MaterialDesignColor.Lime.xaml" />
+            </ResourceDictionary.MergedDictionaries>-->
+            
+            <u:ViewModelLocator x:Key="Locator" />
+            <c:SharedValueConverter x:Key="SharedConverter" />
+            <c:BooleanToVisibilityConverter x:Key="TrueToVisibileConverter" True="Visible" False="Collapsed" />
+            <c:BooleanToVisibilityConverter x:Key="FalseToVisibleConverter" True="Collapsed" False="Visible" />
+            <c:InverseCombineAndBooleansConverter x:Key="InverseCombineBooleanConverter" />
+        </ResourceDictionary>
+    </Application.Resources>
 </Application>

--- a/FitnessTracker/FitnessTracker.csproj
+++ b/FitnessTracker/FitnessTracker.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWPF>true</UseWPF>
     <StartupObject>FitnessTracker.App</StartupObject>
   </PropertyGroup>
@@ -26,12 +26,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Update="Views\MovementChartView.xaml.cs">
-      <SubType>Code</SubType>
-    </Compile>
-  </ItemGroup>
-
-  <ItemGroup>
     <None Update="data.dat">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -39,11 +33,4 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
-  <ItemGroup>
-    <Page Update="Views\MovementChartView.xaml">
-      <SubType>Designer</SubType>
-    </Page>
-  </ItemGroup>
-
 </Project>

--- a/FitnessTracker/Views/MainWindowView.xaml
+++ b/FitnessTracker/Views/MainWindowView.xaml
@@ -3,9 +3,17 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-		xmlns:v="clr-namespace:FitnessTracker.Views"
+        xmlns:v="clr-namespace:FitnessTracker.Views"
+        xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
         mc:Ignorable="d"
-		DataContext="{Binding Source={StaticResource Locator}, Path=MainViewModel}"
+        TextElement.Foreground="{DynamicResource MaterialDesignBody}"
+        TextElement.FontWeight="Regular"
+        TextElement.FontSize="13"
+        TextOptions.TextFormattingMode="Ideal" 
+        TextOptions.TextRenderingMode="Auto"
+        Background="{DynamicResource MaterialDesignPaper}"
+        FontFamily="{materialDesign:MaterialDesignFont}" 
+        DataContext="{Binding Source={StaticResource Locator}, Path=MainViewModel}"
         Title="MainWindow" Height="1000" Width="1600">
 	<DockPanel>
 		<Menu DockPanel.Dock="Top">


### PR DESCRIPTION
The main issue is the project was using .NET Core 3.0. This version reached end of life back in March 2020. https://devblogs.microsoft.com/dotnet/net-core-3-0-end-of-life/

I also added in the basics for font size, and roboto font in the MainWindow.

Also inside of the csproj it appears that MovementChartView may have been inadvertently added with default settings. I removed these as they should not be needed.