### PR TITLE
Added app.config for data source and debug logging of EF SQL.

### DIFF
--- a/FitnessTracker/App.config
+++ b/FitnessTracker/App.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <connectionStrings>
+	<add name="DataFileConnectionString" connectionString="Data Source=data.dat"/>
+  </connectionStrings>
+  <appSettings>
+	<add key="LogEntitySQLToDebugWindow" value="true" />
+  </appSettings>
+</configuration>

--- a/FitnessTracker/App.xaml.cs
+++ b/FitnessTracker/App.xaml.cs
@@ -57,6 +57,7 @@ namespace FitnessTracker
 			services.AddTransient<IDataImporterService, DataImporterService>();
 			services.AddTransient<IDataCalculatorService, DataCalculatorService>();
 			services.AddTransient<IFileDialogService, FileDialogService>();
+			services.AddTransient<IConfigurationService, ConfigurationService>();
 		}
 
 		private void OnStartup(object sender, StartupEventArgs e)

--- a/FitnessTracker/Models/DatabaseContext.cs
+++ b/FitnessTracker/Models/DatabaseContext.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using FitnessTracker.Services.Interfaces;
+using FitnessTracker.Utilities;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
 namespace FitnessTracker.Models
@@ -6,14 +8,25 @@ namespace FitnessTracker.Models
 	public class DatabaseContext : DbContext
 	{
 		public static readonly ILoggerFactory SqlLogger = LoggerFactory.Create(builder => builder.AddDebug());
+		private readonly IConfigurationService _configurationService;
+
+		public DatabaseContext(IConfigurationService configurationService)
+		{
+			Guard.AgainstNull(configurationService, nameof(configurationService));
+			_configurationService = configurationService;
+		}
 
 		public DbSet<DailyRecord> Records { get; set; }
 
 		protected override void OnConfiguring(DbContextOptionsBuilder options)
 		{
-			options.EnableSensitiveDataLogging();
-			options.UseLoggerFactory(SqlLogger);
-			options.UseSqlite("Data Source=data.dat");
+			if (_configurationService.LogEntitySQLToDebugWindow)
+			{
+				options.EnableSensitiveDataLogging();
+				options.UseLoggerFactory(SqlLogger);
+			}
+
+			options.UseSqlite(_configurationService.DatabaseConnectionString);
 		}
 
 		protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/FitnessTracker/Services/Implementations/ConfigurationService.cs
+++ b/FitnessTracker/Services/Implementations/ConfigurationService.cs
@@ -1,0 +1,15 @@
+﻿using System.Configuration;
+using FitnessTracker.Services.Interfaces;
+
+namespace FitnessTracker.Services.Implementations
+{
+	public class ConfigurationService : IConfigurationService
+	{
+		private const string CONNECTIONSTRING_KEY = "DataFileConnectionString";
+		private const string LOGENTITYSQLTODEBUGWINDOW_KEY = "LogEntitySQLToDebugWindow";
+
+		public string DatabaseConnectionString => ConfigurationManager.ConnectionStrings[CONNECTIONSTRING_KEY].ConnectionString;
+
+		public bool LogEntitySQLToDebugWindow => bool.Parse(ConfigurationManager.AppSettings[LOGENTITYSQLTODEBUGWINDOW_KEY]);
+	}
+}

--- a/FitnessTracker/Services/Interfaces/IConfigurationService.cs
+++ b/FitnessTracker/Services/Interfaces/IConfigurationService.cs
@@ -1,0 +1,9 @@
+﻿namespace FitnessTracker.Services.Interfaces
+{
+	public interface IConfigurationService
+	{
+		public string DatabaseConnectionString { get; }
+
+		public bool LogEntitySQLToDebugWindow { get; }
+	}
+}


### PR DESCRIPTION
Added app.config.  Currently has two settings:

`DataFileConnectionString`: Connection string to the data source (`data.dat`)
`LogEntitySQLToDebugWindow`: True to log all entity framework SQL to the debug window; otherwise false.  Defaults to true.

Fixes #4 