### PR TITLE
Added visual defaults for cases where there's no data, and bug fixes.

### DIFF
--- a/FitnessTracker/App.xaml
+++ b/FitnessTracker/App.xaml
@@ -17,7 +17,8 @@
             <u:ViewModelLocator x:Key="Locator" />
             <c:SharedValueConverter x:Key="SharedConverter" />
             <c:InverseCombineAndBooleansConverter x:Key="InverseCombineBooleanConverter" />
-			<BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+			<c:BooleanToVisibilityConverter x:Key="TrueToVisibleConverter" True="Visible" False="Collapsed" />
+			<c:BooleanToVisibilityConverter x:Key="FalseToVisibleConverter" True="Collapsed" False="Visible" />
 		</ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/FitnessTracker/Converters/BooleanToVisibilityConverter.cs
+++ b/FitnessTracker/Converters/BooleanToVisibilityConverter.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace FitnessTracker.Converters
+{
+	// Code taken from the below post.  I like this as a solution much better than creating a simple inverted converter using the built-in
+	// BooleanToVisibilityConverter in WPF.  I don't know why Microsoft didn't just include a negated version by default.  It's a common
+	// enough pattern.
+	//
+	// https://stackoverflow.com/questions/534575/how-do-i-invert-booleantovisibilityconverter
+	public class BooleanConverter<T> : IValueConverter
+	{
+		public BooleanConverter(T trueValue, T falseValue)
+		{
+			True = trueValue;
+			False = falseValue;
+		}
+
+		public T True { get; set; }
+
+		public T False { get; set; }
+
+		public virtual object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			return value is bool && ((bool)value) ? True : False;
+		}
+
+		public virtual object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			return value is T && EqualityComparer<T>.Default.Equals((T)value, True);
+		}
+	}
+
+	public sealed class BooleanToVisibilityConverter : BooleanConverter<Visibility>
+	{
+		public BooleanToVisibilityConverter() : base(Visibility.Visible, Visibility.Collapsed)
+		{
+		}
+	}
+}

--- a/FitnessTracker/Messages/NotifyDataExistsMessage.cs
+++ b/FitnessTracker/Messages/NotifyDataExistsMessage.cs
@@ -1,0 +1,15 @@
+﻿using GalaSoft.MvvmLight.Messaging;
+
+namespace FitnessTracker.Messages
+{
+	/// <summary>
+	/// Used to alert listeners that data may or may not exist for cases when listeners
+	/// only need to have a yes/no answer and not a copy of the entire data set.
+	/// </summary>
+	public class NotifyDataExistsMessage : NotificationMessage<bool>
+	{
+		public NotifyDataExistsMessage(bool dataExists) : base(dataExists, null)
+		{
+		}
+	}
+}

--- a/FitnessTracker/Models/SummaryStatistics.cs
+++ b/FitnessTracker/Models/SummaryStatistics.cs
@@ -6,26 +6,26 @@ namespace FitnessTracker.Models
 {
 	public class SummaryStatistics
 	{
-		public double CurrentWeight { get; set; }
+		public double? CurrentWeight { get; set; }
 
-		public double TotalWeightChange { get; set; }
+		public double? TotalWeightChange { get; set; }
 
-		public double LowestWeight { get; set; }
+		public double? LowestWeight { get; set; }
 
-		public DateTime LowestWeightDate { get; set; }
+		public DateTime? LowestWeightDate { get; set; }
 
-		public double HighestWeight { get; set; }
+		public double? HighestWeight { get; set; }
 		
-		public DateTime HighestWeightDate { get; set; }
+		public DateTime? HighestWeightDate { get; set; }
 
-		public double WeightChangeSincePrevious { get; set; }
+		public double? WeightChangeSincePrevious { get; set; }
 
-		public double TotalDistanceMoved { get; set;  }
+		public double? TotalDistanceMoved { get; set;  }
 
-		public double LargestDistanceMoved { get; set; }
+		public double? LargestDistanceMoved { get; set; }
 
-		public DateTime LargestDistanceMovedDate { get; set; }
+		public DateTime? LargestDistanceMovedDate { get; set; }
 
-		public double AverageDistanceMoved { get; set; }
+		public double? AverageDistanceMoved { get; set; }
 	}
 }

--- a/FitnessTracker/ViewModels/MainViewModel.cs
+++ b/FitnessTracker/ViewModels/MainViewModel.cs
@@ -15,6 +15,8 @@ namespace FitnessTracker.ViewModels
 
 		private const string IMPORT_FILE_FILTER = "Comma-Separated Files|*.csv";
 
+		private bool _canShowGraphs;
+
 		public MainViewModel(IDataImporterService importerService, IFileDialogService fileDialogService, ISettingsService settingsService)
 		{
 			Guard.AgainstNull(importerService, nameof(importerService));
@@ -25,7 +27,15 @@ namespace FitnessTracker.ViewModels
 			_fileDialogService = fileDialogService;
 			_settingsService = settingsService;
 
+			MessengerInstance.Register<NotifyDataExistsMessage>(this, msg => CanShowGraphs = msg.Content);
+
 			ImportCommand = new RelayCommand(async () => await ImportAsync());
+		}
+
+		public bool CanShowGraphs
+		{
+			get => _canShowGraphs;
+			set => Set(nameof(CanShowGraphs), ref _canShowGraphs, value);
 		}
 
 		public RelayCommand ImportCommand { get; }

--- a/FitnessTracker/ViewModels/MovementChartViewModel.cs
+++ b/FitnessTracker/ViewModels/MovementChartViewModel.cs
@@ -16,8 +16,8 @@ namespace FitnessTracker.ViewModels
 	public class MovementChartViewModel : ViewModelBase
 	{
 		private readonly ISettingsService _settingsService;
-		private LineSeries _currentWeightSeries;
-		private LineSeries _averageWeightSeries;
+		private LineSeries _currentDistanceSeries;
+		private LineSeries _averageDistanceSeries;
 		private SystemSettings _systemSettings;
 
 		public MovementChartViewModel(ISettingsService settingsService)
@@ -36,6 +36,8 @@ namespace FitnessTracker.ViewModels
 			SystemSettings = _settingsService.ReadSettings();
 		}
 
+		public bool CanShowGraphs => _currentDistanceSeries.Values.Count > 0 && _averageDistanceSeries.Values.Count > 0;
+
 		public SystemSettings SystemSettings
 		{
 			get => _systemSettings ?? new SystemSettings();
@@ -48,19 +50,21 @@ namespace FitnessTracker.ViewModels
 
 		private void UpdateData(List<DailyRecord> data)
 		{
-			_currentWeightSeries.Values.Clear();
-			_averageWeightSeries.Values.Clear();
+			_currentDistanceSeries.Values.Clear();
+			_averageDistanceSeries.Values.Clear();
 
 			for (int i = 0; i < data.Count; i++)
 			{
-				_currentWeightSeries.Values.Add(new DateSeriesValue { DateTime = data[i].Date, Value = data[i].DistanceMoved });
-				_averageWeightSeries.Values.Add(new DateSeriesValue { DateTime = data[i].Date, Value = data[i].AverageDistanceMoved});
+				_currentDistanceSeries.Values.Add(new DateSeriesValue { DateTime = data[i].Date, Value = data[i].DistanceMoved });
+				_averageDistanceSeries.Values.Add(new DateSeriesValue { DateTime = data[i].Date, Value = data[i].AverageDistanceMoved});
 			}
+
+			RaisePropertyChanged(nameof(CanShowGraphs));
 		}
 
 		private void InitializeWeightSeries()
 		{
-			_currentWeightSeries = new LineSeries
+			_currentDistanceSeries = new LineSeries
 			{
 				Title = "Daily",
 				Values = new ChartValues<DateSeriesValue>(),
@@ -71,7 +75,7 @@ namespace FitnessTracker.ViewModels
 				Fill = Brushes.Transparent
 			};
 
-			_averageWeightSeries = new LineSeries
+			_averageDistanceSeries = new LineSeries
 			{
 				Title = "Average",
 				Values = new ChartValues<DateSeriesValue>(),
@@ -84,7 +88,7 @@ namespace FitnessTracker.ViewModels
 				.X(model => (double)model.DateTime.Ticks / TimeSpan.FromDays(1).Ticks)
 				.Y(model => model.Value ?? double.NaN);
 
-			SeriesData = new SeriesCollection(config) { _currentWeightSeries, _averageWeightSeries };
+			SeriesData = new SeriesCollection(config) { _currentDistanceSeries, _averageDistanceSeries };
 			Formatter = value => new DateTime((long)(value * TimeSpan.FromDays(1).Ticks)).ToString("d");
 		}
 	}

--- a/FitnessTracker/ViewModels/RawDataViewModel.cs
+++ b/FitnessTracker/ViewModels/RawDataViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.ObjectModel;
+using System.Linq;
 using System.Threading.Tasks;
 using FitnessTracker.Messages;
 using FitnessTracker.Models;
@@ -35,6 +36,7 @@ namespace FitnessTracker.ViewModels
 			Data = new ObservableCollection<DailyRecord>(newData);
 
 			MessengerInstance.Send(new DataRetrievedMessage(newData));
+			MessengerInstance.Send(new NotifyDataExistsMessage(newData.Any()));
 		}
 	}
 }

--- a/FitnessTracker/ViewModels/SummaryViewModel.cs
+++ b/FitnessTracker/ViewModels/SummaryViewModel.cs
@@ -37,8 +37,35 @@ namespace FitnessTracker.ViewModels
 		public SummaryStatistics SummaryData
 		{
 			get => _summaryStatistics;
-			set => Set(nameof(SummaryData), ref _summaryStatistics, value);
+			set
+			{
+				Set(nameof(SummaryData), ref _summaryStatistics, value);
+				RaisePropertyChanged(nameof(CurrentWeight));
+				RaisePropertyChanged(nameof(TotalWeightChange));
+				RaisePropertyChanged(nameof(WeightChangeSinceLast));
+				RaisePropertyChanged(nameof(LowestWeight));
+				RaisePropertyChanged(nameof(HighestWeight));
+				RaisePropertyChanged(nameof(TotalDistanceMoved)); 
+				RaisePropertyChanged(nameof(AverageDistanceMoved));
+				RaisePropertyChanged(nameof(LargestDistanceMoved));
+			}
 		}
+
+		public double? CurrentWeight => _summaryStatistics?.CurrentWeight;
+
+		public double? TotalWeightChange => _summaryStatistics?.TotalWeightChange;
+
+		public double? WeightChangeSinceLast => _summaryStatistics?.WeightChangeSincePrevious;
+
+		public double? LowestWeight => _summaryStatistics?.LowestWeight;
+
+		public double? HighestWeight => _summaryStatistics?.HighestWeight;
+
+		public double? TotalDistanceMoved => _summaryStatistics?.TotalDistanceMoved;
+
+		public double? AverageDistanceMoved => _summaryStatistics?.AverageDistanceMoved;
+		
+		public double? LargestDistanceMoved => _summaryStatistics?.LargestDistanceMoved;
 
 		public SystemSettings SystemSettings
 		{

--- a/FitnessTracker/ViewModels/WeightChartViewModel.cs
+++ b/FitnessTracker/ViewModels/WeightChartViewModel.cs
@@ -39,6 +39,8 @@ namespace FitnessTracker.ViewModels
 
 		public SeriesCollection SeriesData { get; private set; }
 
+		public bool CanShowGraphs => _currentWeightSeries.Values.Count > 0 && _averageWeightSeries.Values.Count > 0;
+
 		public SystemSettings SystemSettings
 		{
 			get =>_systemSettings ?? new SystemSettings();
@@ -57,6 +59,8 @@ namespace FitnessTracker.ViewModels
 				_currentWeightSeries.Values.Add(new DateSeriesValue { DateTime = data[i].Date, Value = data[i].Weight });
 				_averageWeightSeries.Values.Add(new DateSeriesValue { DateTime = data[i].Date, Value = data[i].MovingWeightAverage });
 			}
+
+			RaisePropertyChanged(nameof(CanShowGraphs));
 		}
 
 		private void InitializeWeightSeries()

--- a/FitnessTracker/Views/MainWindowView.xaml
+++ b/FitnessTracker/Views/MainWindowView.xaml
@@ -25,9 +25,10 @@
 			<Grid Grid.Row="2">
 				<Grid.RowDefinitions>
 					<RowDefinition Height="38"/>
+					<RowDefinition Height="50"/>
 					<RowDefinition Height="*"/>
 				</Grid.RowDefinitions>
-				<materialDesign:ColorZone Mode="PrimaryDark" Padding="0">
+				<materialDesign:ColorZone Mode="PrimaryDark" Padding="0" Grid.Row="0">
 					<Grid>
 						<Grid.ColumnDefinitions>
 							<ColumnDefinition Width="*" />
@@ -51,21 +52,38 @@
 						</StackPanel>
 					</Grid>
 				</materialDesign:ColorZone>
-				<Grid Grid.Row="1">
-					<Grid Visibility="{Binding IsChecked, ElementName=rbTab1, Converter={StaticResource BooleanToVisibilityConverter}}">
-						<Grid>
+				<v:AddEditDataView Grid.Row="1" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+				<Grid Grid.Row="2">
+					<Grid Visibility="{Binding IsChecked, ElementName=rbTab1, Converter={StaticResource TrueToVisibleConverter}}">
+						<Border Visibility="{Binding CanShowGraphs, Converter={StaticResource FalseToVisibleConverter}}">
+							<TextBlock FontSize="40" 
+										   Foreground="{DynamicResource SecondaryHueMidBrush}"
+										   VerticalAlignment="Center"
+										   HorizontalAlignment="Center">
+									Import or enter data to see graphs.
+							</TextBlock>
+						</Border>
+						<Grid Visibility="{Binding CanShowGraphs, Converter={StaticResource TrueToVisibleConverter}}">
 							<Grid.RowDefinitions>
-								<RowDefinition Height="50" />
 								<RowDefinition />
 								<RowDefinition />
 							</Grid.RowDefinitions>
-							<v:AddEditDataView Grid.Row="0" HorizontalAlignment="Center" VerticalAlignment="Center"/>
-							<v:WeightChartView Grid.Row="1"/>
-							<v:MovementChartView Grid.Row="2" />
+							<v:WeightChartView Grid.Row="0"/>
+							<v:MovementChartView Grid.Row="1" />
 						</Grid>
 					</Grid>
-					<Grid Visibility="{Binding IsChecked, ElementName=rbTab2, Converter={StaticResource BooleanToVisibilityConverter}}">
-						<v:RawDataView />
+					<Grid Visibility="{Binding IsChecked, ElementName=rbTab2, Converter={StaticResource TrueToVisibleConverter}}">
+						<Border Visibility="{Binding CanShowGraphs, Converter={StaticResource FalseToVisibleConverter}}">
+							<TextBlock FontSize="40" 
+										   Foreground="{DynamicResource SecondaryHueMidBrush}"
+										   VerticalAlignment="Center"
+										   HorizontalAlignment="Center">
+									Import or enter data to see graphs.
+							</TextBlock>
+						</Border>
+						<Border BorderThickness="0" Visibility="{Binding CanShowGraphs, Converter={StaticResource TrueToVisibleConverter}}" >
+							<v:RawDataView />
+						</Border>
 					</Grid>
 				</Grid>
 			</Grid>

--- a/FitnessTracker/Views/RawDataView.xaml
+++ b/FitnessTracker/Views/RawDataView.xaml
@@ -7,7 +7,7 @@
 			 DataContext="{Binding Source={StaticResource Locator}, Path=RawDataViewModel}"
              d:DesignHeight="450" d:DesignWidth="800">
 	<Grid>
-		<DataGrid ItemsSource="{Binding Data}" AutoGenerateColumns="False">
+		<DataGrid ItemsSource="{Binding Data}" AutoGenerateColumns="False" CanUserAddRows="False">
 			<DataGrid.Columns>
 				<DataGridTextColumn Header="Date" Binding="{Binding Date, StringFormat=d}" />
 				<DataGridTextColumn Header="Weight" Binding="{Binding Weight, StringFormat=N1}" />

--- a/FitnessTracker/Views/SettingsView.xaml
+++ b/FitnessTracker/Views/SettingsView.xaml
@@ -95,7 +95,7 @@
 					<TextBox Grid.Column="4" 
 							 Grid.Row="1" 
 							 Width="50" 
-							 Visibility="{Binding ElementName=WeightMinOverride, Path=IsChecked, Converter={StaticResource BooleanToVisibilityConverter}}"
+							 Visibility="{Binding ElementName=WeightMinOverride, Path=IsChecked, Converter={StaticResource TrueToVisibleConverter}}"
 							 Text="{Binding WeightGraphMinimum, FallbackValue=0}"/>
 
 					<TextBlock Grid.Column="0" 
@@ -111,7 +111,7 @@
 					<TextBox Grid.Column="4" 
 							 Grid.Row="2" 
 							 Width="50" 
-							 Visibility="{Binding ElementName=WeightMaxOverride, Path=IsChecked, Converter={StaticResource BooleanToVisibilityConverter}}"
+							 Visibility="{Binding ElementName=WeightMaxOverride, Path=IsChecked, Converter={StaticResource TrueToVisibleConverter}}"
 							 Text="{Binding WeightGraphMaximum, FallbackValue=0}"/>
 
 					<TextBlock Grid.Column="0" 
@@ -135,7 +135,7 @@
 					<TextBox Grid.Column="4" 
 							 Grid.Row="5" 
 							 Width="50"
-							 Visibility="{Binding ElementName=DistanceMinOverride, Path=IsChecked, Converter={StaticResource BooleanToVisibilityConverter}}"
+							 Visibility="{Binding ElementName=DistanceMinOverride, Path=IsChecked, Converter={StaticResource TrueToVisibleConverter}}"
 							 Text="{Binding DistanceGraphMinimum, FallbackValue=0}"/>
 
 					<TextBlock Grid.Column="0" 
@@ -151,7 +151,7 @@
 					<TextBox Grid.Column="4" 
 							 Grid.Row="6" 
 							 Width="50"
-							 Visibility="{Binding ElementName=DistanceMaxOverride, Path=IsChecked, Converter={StaticResource BooleanToVisibilityConverter}}"
+							 Visibility="{Binding ElementName=DistanceMaxOverride, Path=IsChecked, Converter={StaticResource TrueToVisibleConverter}}"
 							 Text="{Binding DistanceGraphMaximum, FallbackValue=0}"/>
 				</Grid>
 			</GroupBox>

--- a/FitnessTracker/Views/SummaryView.xaml
+++ b/FitnessTracker/Views/SummaryView.xaml
@@ -3,21 +3,24 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-			 xmlns:m="clr-namespace:FitnessTracker.Models"
-             mc:Ignorable="d" 
+			 xmlns:m="clr-namespace:FitnessTracker.Models" xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+			 mc:Ignorable="d" 
 			 Width="175"
 			 DataContext="{Binding Source={StaticResource Locator}, Path=SummaryViewModel}">
 	<Border BorderBrush="#888888" BorderThickness="1 0 0 0">
-		<Grid ScrollViewer.VerticalScrollBarVisibility="Auto">
+		<Grid>
 			<Grid.RowDefinitions>
 				<RowDefinition Height="Auto" />
 				<RowDefinition Height="0.5*" />
 				<RowDefinition Height="10" />
 				<RowDefinition Height="Auto" />
 				<RowDefinition Height="0.5*" />
+				<RowDefinition Height="Auto" />
 			</Grid.RowDefinitions>
 			<Border Grid.Row="0" Padding="3" Background="{DynamicResource PrimaryHueMidBrush}">
-				<TextBlock FontWeight="Bold" FontSize="14" Foreground="{DynamicResource PrimaryHueMidForegroundBrush}" Text="{Binding SystemSettings.WeightUnit, StringFormat='Weight ({0})', FallbackValue={x:Static m:WeightUnit.Pounds}}" />
+				<StackPanel Orientation="Horizontal">
+					<TextBlock FontWeight="Bold" FontSize="14" Foreground="{DynamicResource PrimaryHueMidForegroundBrush}" Text="{Binding SystemSettings.WeightUnit, StringFormat='Weight ({0})', FallbackValue={x:Static m:WeightUnit.Pounds}}" />
+				</StackPanel>
 			</Border>
 			<Grid Grid.Row="1" Margin="3 0 0 0">
 				<Grid.RowDefinitions>
@@ -30,42 +33,47 @@
 					<RowDefinition Height="Auto" />
 					<RowDefinition Height="10" />
 					<RowDefinition Height="Auto" />
+					<RowDefinition Height="*" />
 				</Grid.RowDefinitions>
 
 				<StackPanel Grid.Row="0">
-					<StackPanel Orientation="Horizontal">
-						<TextBlock FontWeight="Bold" Foreground="{DynamicResource SecondaryHueLightBrush}" Text="Current" />
-						<TextBlock Foreground="{DynamicResource SecondaryHueLightBrush}" Margin="5 0 0 0" FontSize="10" VerticalAlignment="Center">(based on 5-day average)</TextBlock>
-					</StackPanel>
-					
-					<TextBlock FontWeight="Bold" FontSize="14" Text="{Binding SummaryData.CurrentWeight, StringFormat=N1}" />
+					<TextBlock FontWeight="Bold" Foreground="{DynamicResource SecondaryHueLightBrush}" Text="Current" />
+					<TextBlock FontWeight="Bold" FontSize="14" Text="{Binding CurrentWeight, StringFormat=N1, TargetNullValue='(no data)'}" />
 				</StackPanel>
 
 				<StackPanel Grid.Row="2">
 					<TextBlock FontWeight="Bold" Foreground="{DynamicResource SecondaryHueLightBrush}" Text="Total Gain/Loss" />
-					<TextBlock FontWeight="Bold" FontSize="14" Text="{Binding SummaryData.TotalWeightChange, StringFormat=N1}" />
+					<TextBlock FontWeight="Bold" FontSize="14" Text="{Binding TotalWeightChange, StringFormat=N1, TargetNullValue='(no data)'}" />
 				</StackPanel>
 
 				<StackPanel Grid.Row="4">
 					<TextBlock FontWeight="Bold" Foreground="{DynamicResource SecondaryHueLightBrush}" Text="Change Since Previous: " />
-					<TextBlock FontWeight="Bold" FontSize="14" Text="{Binding SummaryData.WeightChangeSincePrevious, StringFormat=N1}" />
+					<TextBlock FontWeight="Bold" FontSize="14" Text="{Binding WeightChangeSinceLast, StringFormat=N1, TargetNullValue='(no data)'}" />
 				</StackPanel>
 
 				<StackPanel Grid.Row="6">
 					<TextBlock FontWeight="Bold" Foreground="{DynamicResource SecondaryHueLightBrush}" Text="Lowest (all-time): " />
 					<StackPanel Orientation="Horizontal">
-						<TextBlock FontWeight="Bold" FontSize="14" Text="{Binding SummaryData.LowestWeight, StringFormat=N1}" />
-						<TextBlock Margin="2 0 0 0" VerticalAlignment="Center" Text="{Binding SummaryData.LowestWeightDate, StringFormat='({0:d})'}"/>
+						<TextBlock FontWeight="Bold" FontSize="14" Text="{Binding LowestWeight, StringFormat=N1, TargetNullValue='(no data)'}" />
+						<TextBlock Margin="2 0 0 0" VerticalAlignment="Center" Text="{Binding SummaryData.LowestWeightDate, StringFormat=' {0:d}'}"/>
 					</StackPanel>
 				</StackPanel>
 
 				<StackPanel Grid.Row="8">
 					<TextBlock FontWeight="Bold" Foreground="{DynamicResource SecondaryHueLightBrush}" Text="Highest (all-time): " />
 					<StackPanel Orientation="Horizontal">
-						<TextBlock FontWeight="Bold" FontSize="14" Text="{Binding SummaryData.HighestWeight, StringFormat=N1}" />
-						<TextBlock Margin="2 0 0 0" VerticalAlignment="Center" Text="{Binding SummaryData.HighestWeightDate, StringFormat='({0:d})'}" />
+						<TextBlock FontWeight="Bold" FontSize="14" Text="{Binding HighestWeight, StringFormat=N1, TargetNullValue='(no data)'}" />
+						<TextBlock Margin="2 0 0 0" VerticalAlignment="Center" Text="{Binding SummaryData.HighestWeightDate, StringFormat=' {0:d}'}" />
 					</StackPanel>
 				</StackPanel>
+
+				<StackPanel Grid.Row="9" Margin="0 5 0 0">
+					<Separator />
+					<TextBlock Foreground="{DynamicResource SecondaryHueDarkBrush}" TextWrapping="Wrap" Margin="0 5 0 0">
+					Based on a 5-day average.   Data will not show up until there are at least 5 days entered.
+					</TextBlock>
+				</StackPanel>
+
 			</Grid>
 			<Border Grid.Row="3" Padding="3" Background="{DynamicResource PrimaryHueMidBrush}">
 				<TextBlock FontWeight="Bold" FontSize="14" Foreground="{DynamicResource PrimaryHueMidForegroundBrush}" Text="{Binding SystemSettings.DistanceUnit, StringFormat='Distance ({0})', FallbackValue={x:Static m:DistanceUnit.Miles}}" />
@@ -81,19 +89,19 @@
 
 				<StackPanel Grid.Row="0">
 					<TextBlock FontWeight="Bold" Foreground="{DynamicResource SecondaryHueLightBrush}" VerticalAlignment="Center" Text="Total" />
-					<TextBlock FontWeight="Bold" FontSize="14" Text="{Binding SummaryData.TotalDistanceMoved, StringFormat=N2}" />
+					<TextBlock FontWeight="Bold" FontSize="14" Text="{Binding TotalDistanceMoved, StringFormat=N2, TargetNullValue='(no data)'}" />
 				</StackPanel>
 
 				<StackPanel Grid.Row="2">
 					<TextBlock FontWeight="Bold" Foreground="{DynamicResource SecondaryHueLightBrush}" VerticalAlignment="Center" Text="Average" />
-					<TextBlock FontWeight="Bold" FontSize="14" Text="{Binding SummaryData.AverageDistanceMoved, StringFormat=N2}" />
+					<TextBlock FontWeight="Bold" FontSize="14" Text="{Binding AverageDistanceMoved, StringFormat=N2, TargetNullValue='(no data)'}" />
 				</StackPanel>
 
 				<StackPanel Grid.Row="4" >
 					<TextBlock FontWeight="Bold" Foreground="{DynamicResource SecondaryHueLightBrush}" VerticalAlignment="Center" Text="Longest (all-time): " />
 					<StackPanel Orientation="Horizontal">
-						<TextBlock FontWeight="Bold" FontSize="14" Text="{Binding SummaryData.LargestDistanceMoved, StringFormat=N2}" />
-						<TextBlock VerticalAlignment="Center" Margin="2 0 0 0" Text="{Binding SummaryData.LargestDistanceMovedDate, StringFormat='({0:d})'}"/>
+						<TextBlock FontWeight="Bold" FontSize="14" Text="{Binding LargestDistanceMoved, StringFormat=N2, TargetNullValue='(no data)'}" />
+						<TextBlock VerticalAlignment="Center" FontSize="10" Margin="2 0 0 0" Text="{Binding SummaryData.LargestDistanceMovedDate, StringFormat=' {0:d}'}"/>
 					</StackPanel>
 				</StackPanel>
 			</Grid>


### PR DESCRIPTION
* Added visual defaults for cases where there's no/not enough data.
* Fixed an issue where the first moving average for weight isn't calculated until day 6 instead of 5.
* Added a note to the Weight section of the `SummaryView` about data being based on averages.
* Bug fixes with how summary statistics are calculated around scenarios where there isn't enough data.

Fixes #15 
Fixes #20 