### PR TITLE
Renamed default data file and modified import to support 1.0 data files (.dat) as well.

### DIFF
--- a/FitnessTracker.Core.Tests/Helpers/Builders/DataServiceBuilder.cs
+++ b/FitnessTracker.Core.Tests/Helpers/Builders/DataServiceBuilder.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using FitnessTracker.Core.Models;
 using FitnessTracker.Core.Services.Implementations;
 using FitnessTracker.Core.Services.Interfaces;
+using FitnessTracker.Services.Implementations;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 
@@ -47,8 +48,8 @@ namespace FitnessTracker.Core.Tests.Helpers.Builders
 
 		private void SetupMocks()
 		{
-			var configMock = new Mock<IConfigurationService>();
-			configMock.Setup(svc => svc.DatabaseConnectionString).Returns($"Data Source={Constants.TEST_DATABASE_FILENAME}");
+			var configMock = new Mock<ConfigurationService>() { CallBase = true };
+			configMock.Setup(svc => svc.DataFileName).Returns(Constants.TEST_DATABASE_FILENAME);
 			ConfigurationService = configMock.Object;
 
 			_dataCalculatorServiceMock = new Mock<IDataCalculatorService>();

--- a/FitnessTracker.Core.Tests/Helpers/Builders/SettingsServiceBuilder.cs
+++ b/FitnessTracker.Core.Tests/Helpers/Builders/SettingsServiceBuilder.cs
@@ -25,7 +25,7 @@ namespace FitnessTracker.Core.Tests.Helpers.Builders
 		private void CreateMocks()
 		{
 			var mock = new Mock<IConfigurationService>();
-			mock.Setup(svc => svc.SettingsFilename).Returns(Constants.TEST_SETTINGS_FILENAME);
+			mock.Setup(svc => svc.SettingsFileName).Returns(Constants.TEST_SETTINGS_FILENAME);
 			ConfigurationService = mock.Object;
 		}
 	}

--- a/FitnessTracker.Core.Tests/ImportPreparer/SqliteImportPreparerTests.cs
+++ b/FitnessTracker.Core.Tests/ImportPreparer/SqliteImportPreparerTests.cs
@@ -7,6 +7,7 @@ using FitnessTracker.Core.Services.Implementations;
 using FitnessTracker.Core.Services.Interfaces;
 using FitnessTracker.Core.Tests.Helpers;
 using FitnessTracker.Core.Tests.Helpers.Builders;
+using FitnessTracker.Services.Implementations;
 using Microsoft.Data.Sqlite;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -23,11 +24,10 @@ namespace FitnessTracker.Core.Tests.ImportPreparer
 
 		public SqliteImportPreparerTests()
 		{
-			var configMock = new Mock<IConfigurationService>();
-			configMock.Setup(c => c.DatabaseConnectionString).Returns($"Data Source={Constants.IMPORT_DATABASE_FILENAME}");
+			var configMock = new Mock<ConfigurationService>() { CallBase = true };
+			configMock.Setup(c => c.DataFileName).Returns(Constants.IMPORT_DATABASE_FILENAME);
 
 			DatabaseService = new DatabaseService(new DataCalculatorService(), configMock.Object);
-
 		}
 
 		[TestInitialize]

--- a/FitnessTracker.Core/Services/Implementations/ConfigurationService.cs
+++ b/FitnessTracker.Core/Services/Implementations/ConfigurationService.cs
@@ -4,8 +4,11 @@ namespace FitnessTracker.Services.Implementations
 {
 	public class ConfigurationService : IConfigurationService
 	{
-		public string DatabaseConnectionString => "Data Source=data.dat";
+		// Virtual so test classes can override it.
+		public virtual string DataFileName => "FitnessData.ft";
 
-		public string SettingsFilename => "settings.json";
+		public string DatabaseConnectionString => $"Data Source={DataFileName}";
+
+		public string SettingsFileName => "settings.json";
 	}
 }

--- a/FitnessTracker.Core/Services/Implementations/DataImporterService.cs
+++ b/FitnessTracker.Core/Services/Implementations/DataImporterService.cs
@@ -48,7 +48,7 @@ namespace FitnessTracker.Core.Services.Implementations
 			return extension switch
 			{
 				".csv" => FileType.Csv,
-				".dat" => FileType.Sqlite,
+				".dat" or ".ft" => FileType.Sqlite,
 				_ => FileType.Unknown,
 			};
 		}

--- a/FitnessTracker.Core/Services/Implementations/SettingsService.cs
+++ b/FitnessTracker.Core/Services/Implementations/SettingsService.cs
@@ -17,7 +17,7 @@ namespace FitnessTracker.Core.Services.Implementations
 		public SettingsService(IConfigurationService configurationService)
 		{
 			Guard.AgainstNull(configurationService, nameof(configurationService));
-			_filename = configurationService.SettingsFilename;
+			_filename = configurationService.SettingsFileName;
 
 			_serializationOptions = new JsonSerializerOptions
 			{

--- a/FitnessTracker.Core/Services/Interfaces/IConfigurationService.cs
+++ b/FitnessTracker.Core/Services/Interfaces/IConfigurationService.cs
@@ -2,8 +2,10 @@
 {
 	public interface IConfigurationService
 	{
+		public string DataFileName { get; }
+
 		public string DatabaseConnectionString { get; }
 
-		public string SettingsFilename { get; }
+		public string SettingsFileName { get; }
 	}
 }

--- a/FitnessTracker.UI/App.xaml.cs
+++ b/FitnessTracker.UI/App.xaml.cs
@@ -93,7 +93,9 @@ namespace FitnessTracker.UI
 
 		private async Task VerifyOrCreateDatabase()
 		{
-			if (!File.Exists("data.dat"))
+			var configService = ServiceProvider.GetService<IConfigurationService>();
+
+			if (!File.Exists(configService.DataFileName))
 			{
 				var dbService = ServiceProvider.GetService<IDatabaseService>();
 				await dbService.CreateDatabase();

--- a/FitnessTracker.UI/ViewModels/ImportViewModel.cs
+++ b/FitnessTracker.UI/ViewModels/ImportViewModel.cs
@@ -12,7 +12,7 @@ namespace FitnessTracker.UI.ViewModels
 {
 	public class ImportViewModel : ViewModelBase
 	{
-		private const string IMPORT_FILE_FILTER = "Comma-Separated Files|*.csv|FitnessTracker Files|*.dat";
+		private const string IMPORT_FILE_FILTER = "Comma-Separated Files|*.csv|FitnessTracker Data Files|*.ft|FitnessTracker Legacy Data Files|*.dat";
 
 		private readonly IDataImporterService _dataImporterService;
 		private readonly IFileDialogService _fileDialogService;
@@ -111,7 +111,8 @@ namespace FitnessTracker.UI.ViewModels
 			return Path.GetExtension(FileName) switch
 			{
 				".csv" => "Comma-Separated Value",
-				".dat" => "FitnessTracker Data",
+				".dat" => "FitnessTracker Legacy Data",
+				".ft" => "FitnessTracker Data",
 				_ => "Unknown",
 			};
 		}


### PR DESCRIPTION
* Renamed default data file from `data.dat` to `FitnessData.ft`.  File format is unchanged.
* Modified import to support the new file extension.
* Modified import to support importing from 1.0 files (`.dat`).
* Updated unit tests.

Closes #48 